### PR TITLE
Allow sphinx 6 in meta.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About sphinx-basic-ng
-=====================
+About sphinx-basic-ng-feedstock
+===============================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/sphinx-basic-ng-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/pradyunsg/sphinx-basic-ng
 
 Package license: MIT
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/sphinx-basic-ng-feedstock/blob/main/LICENSE.txt)
 
 Summary: A modern skeleton for Sphinx themes.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -20,7 +20,7 @@ requirements:
     - python >=3.7
   run:
     - python >=3.7
-    - sphinx >=4.0,<6.0
+    - sphinx >=4.0,<7.0
 
 test:
   imports:


### PR DESCRIPTION
The current recipe contains a stricter upper limit on Sphinx than mandated by `sphinx-basic-ng`'s `setup.py` or implied by `furo`'s `pyproject.toml` (which uses `sphinx-basic-ng` under the hood and is from the same author)

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

closes #6 